### PR TITLE
set somaxconn default to a sane value

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,7 +45,7 @@ server_pam:
     hard: 999999
 server_sysctl:
   - key: "net.core.somaxconn"
-    value: 999999
+    value: 65535
   - key: "net.ipv4.ip_local_port_range"
     value: "10240 62000"
   - key: "fs.file-max"


### PR DESCRIPTION
Addresses an issue where the default for `net.core.somaxconn` is set to a value that is too large on some systems:

```
[root@server core]# echo 65535 > somaxconn 
[root@server core]# echo 65536 > somaxconn 
bash: echo: write error: Invalid argument
[root@server core]# cat /etc/redhat-release 
CentOS Linux release 7.3.1611 (Core)
```

Since the idea is to just set it to a "don't worry about it" value by default, changing it to the supported max does that.