### PR TITLE
add sysctl's for panic on oom & reboot on panic

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,6 +48,10 @@ server_sysctl:
     value: "10240 62000"
   - key: "fs.file-max"
     value: 999999
+  - key: "vm.panic_on_oom"
+    value: 1
+  - key: "kernel.panic"
+    value: 90
 server_extra_sysctl: {}
 server_ssh_known_hosts_command: "ssh-keyscan -H -T 10"
 server_ssh_known_hosts_file: "/etc/ssh/ssh_known_hosts"


### PR DESCRIPTION
The use of panic_on_oom forces the kernel to throw a panic on oom when oom_killer has failed to resolve an oom situation. Then, kernel.panic forces the system to reboot on all panic events after X seconds instead of the system just hanging @ a panic waiting for intervention for a reboot.

The principle here, is a system locked up at a panic is useless, allow the kernel to get the system back online automatically. The caveat here is we need better tracking of reboot events with a top-list of daily/weekly reboots for sysops to investigate trending hw, software and similar issues that induce reboots (which is needed now anyways).