### PR TITLE
Add tagging & refactor sysctl handling

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,17 +49,50 @@ server_pam:
   nproc:
     soft: 999999
     hard: 999999
+server_set_sysctl_base: true
 server_sysctl:
   - key: "net.core.somaxconn"
-    value: 65535
+    value: 32768
+  - key: "net.core.netdev_max_backlog"
+    value: 32768
+  - key: "net.ipv4.tcp_max_tw_buckets"
+    value: 32768
+  - key: "net.ipv4.tcp_max_syn_backlog"
+    value: 65536
+  - key: "net.ipv4.tcp_syn_retries"
+    value: 2
+  - key: "net.ipv4.tcp_synack_retries"
+    value: 2
+  - key: "net.ipv4.tcp_fin_timeout"
+    value: 15
+  - key: "net.netfilter.nf_conntrack_max"
+    value: 1048576
   - key: "net.ipv4.ip_local_port_range"
     value: "10240 62000"
   - key: "fs.file-max"
-    value: 999999
+    value: 1048576
   - key: "vm.panic_on_oom"
     value: 1
   - key: "kernel.panic"
     value: 90
+server_set_sysctl_10g: False
+server_sysctl_10g:
+  - key: "net.core.rmem_max"
+    value: 16777216
+  - key: "net.core.wmem_max"
+    value: 16777216
+  - key: "net.ipv4.tcp_rmem"
+    value: "4096 87380 16777216"
+  - key: "net.ipv4.tcp_wmem"
+    value: "4096 65536 16777216"
+  - key: "net.ipv4.tcp_slow_start_after_idle"
+    value: 0
+  - key: "net.ipv4.tcp_sack"
+    value: 0
+  - key: "net.ipv4.tcp_window_scaling"
+    value: 1
+  - key: "net.ipv4.tcp_moderate_rcvbuf"
+    value: 1
 server_extra_sysctl: {}
 server_ssh_known_hosts_command: "ssh-keyscan -H -T 10"
 server_ssh_known_hosts_file: "/etc/ssh/ssh_known_hosts"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,6 +49,12 @@ server_pam:
   nproc:
     soft: 999999
     hard: 999999
+  core:
+    soft: 0
+    hard: 0
+  priority:
+    soft: 4
+    hard: 4
 server_set_sysctl_base: true
 server_sysctl:
   - key: "net.core.somaxconn"
@@ -75,7 +81,7 @@ server_sysctl:
     value: 1
   - key: "kernel.panic"
     value: 90
-server_set_sysctl_10g: False
+server_set_sysctl_10g: false
 server_sysctl_10g:
   - key: "net.core.rmem_max"
     value: 16777216

--- a/tasks/limits.yml
+++ b/tasks/limits.yml
@@ -8,9 +8,6 @@
     value="{{ item.value.soft }}"
     use_max="yes"
   with_dict: "{{ server_pam }}"
-  tags:
-    - pam
-    - pam-limits
 
 - name: Set Base PAM Limits (Hard)
   pam_limits:
@@ -20,32 +17,3 @@
     value="{{ item.value.hard }}"
     use_max="yes"
   with_dict: "{{ server_pam }}"
-  tags:
-    - pam
-    - pam-limits
-
-- name: Set Base Sysctl
-  sysctl:
-    name="{{ item.key }}"
-    value="{{ item.value }}"
-    state="present"
-    sysctl_set="yes"
-    ignoreerrors="yes"
-    reload="yes"
-  with_items: "{{ server_sysctl }}"
-  tags:
-    - kernel
-    - kernel-sysctl 
-
-- name: Set Extra Sysctl
-  sysctl:
-    name="{{ item.key }}"
-    value="{{ item.value }}"
-    state="present"
-    sysctl_set="yes"
-    ignoreerrors="yes"
-    reload="yes"
-  with_items: "{{ server_extra_sysctl }}"
-  tags:
-    - kernel
-    - kernel-sysctl

--- a/tasks/limits.yml
+++ b/tasks/limits.yml
@@ -27,6 +27,8 @@
     ignoreerrors="yes"
     reload="yes"
   with_items: "{{ server_sysctl }}"
+  tags:
+    - kernel-sysctl 
 
 - name: Set Extra Sysctl
   sysctl:
@@ -37,3 +39,5 @@
     ignoreerrors="yes"
     reload="yes"
   with_items: "{{ server_extra_sysctl }}"
+  tags:
+    - kernel-sysctl

--- a/tasks/limits.yml
+++ b/tasks/limits.yml
@@ -8,6 +8,9 @@
     value="{{ item.value.soft }}"
     use_max="yes"
   with_dict: "{{ server_pam }}"
+  tags:
+    - pam
+    - pam-limits
 
 - name: Set Base PAM Limits (Hard)
   pam_limits:
@@ -17,6 +20,9 @@
     value="{{ item.value.hard }}"
     use_max="yes"
   with_dict: "{{ server_pam }}"
+  tags:
+    - pam
+    - pam-limits
 
 - name: Set Base Sysctl
   sysctl:
@@ -28,6 +34,7 @@
     reload="yes"
   with_items: "{{ server_sysctl }}"
   tags:
+    - kernel
     - kernel-sysctl 
 
 - name: Set Extra Sysctl
@@ -40,4 +47,5 @@
     reload="yes"
   with_items: "{{ server_extra_sysctl }}"
   tags:
+    - kernel
     - kernel-sysctl

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,7 @@
     - packages
     - extras
 
-- name: Set SELinux
+- name: Set SELinux Enforcing
   selinux:
     policy="targeted"
     state="enforcing"
@@ -52,15 +52,21 @@
     - services
     - unused-services
 
-
 - include: limits.yml
   when: server_adjust_limits
   tags:
     - environment
     - resources
-    - limits
     - pam
     - pam-limits
+
+- include: sysctl.yml
+  when: server_set_sysctl_base
+  tags:
+    - environment
+    - resources
+    - kernel
+    - kernel-sysctl
 
 - name: Setup /etc/hosts
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,9 @@
   hostname:
     name="{{ inventory_hostname }}"
   ignore_errors: "yes"
+  tags:
+    - environment
+    - hostname
 
 - name: Set the Global PATH
   lineinfile:
@@ -11,6 +14,9 @@
     state="present"
     line="PATH={{ server_extra_path }}:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin"
   when: server_extra_path != ''
+  tags:
+    - environment
+    - paths
 
 - name: Install Extras
   yum:
@@ -19,12 +25,20 @@
     disablerepo="*"
     enablerepo="epel,base,updates,nexcess,extras"
   with_items: "{{ server_packages + server_extra_packages }}"
+  tags:
+    - packages
+    - extras
 
 - name: Set SELinux
   selinux:
     policy="targeted"
     state="enforcing"
   when: server_selinux_enforcing
+  tags:
+    - environment
+    - security
+    - selinux
+    - selinux-enforcing
 
 - name: Turn Off Unused Services
   service:
@@ -33,9 +47,20 @@
     state="stopped"
   with_items: "{{ server_services_unused }}"
   ignore_errors: yes
+  tags:
+    - security
+    - services
+    - unused-services
+
 
 - include: limits.yml
   when: server_adjust_limits
+  tags:
+    - environment
+    - resources
+    - limits
+    - pam
+    - pam-limits
 
 - name: Setup /etc/hosts
   template:
@@ -44,22 +69,37 @@
     owner="root"
     group="root"
     mode="0644"
+  tags:
+    - environment
+    - hosts
 
 - name: Make Sure Known Hosts File Exists
   file:
     path="{{ server_ssh_known_hosts_file }}"
     state="touch"
+  tags:
+    - environment
+    - ssh
+    - ssh-known-hosts
 
 - name: Suck in Known Hosts
   shell: "ssh-keygen -f {{ server_ssh_known_hosts_file }} -F {{ item }}"
   with_items: "{{ server_ssh_known_hosts }}"
   register: server_ssh_known_host_results
   ignore_errors: yes
+  tags:
+    - environment
+    - ssh
+    - ssh-known-hosts
 
 - name: Scan the Public Key
   shell: "{{ server_ssh_known_hosts_command }} {{ item.item }} >> {{ server_ssh_known_hosts_file }}"
   with_items: "{{ server_ssh_known_host_results.results }}"
   when: item.stdout == ""
+  tags:
+    - environment
+    - ssh
+    - ssh-public-keys
 
 - name: Setup Bash Aliases
   lineinfile:
@@ -72,7 +112,7 @@
     regexp="^alias {{ item.key }}="
   with_dict: "{{ server_bash_aliases }}"
   tags:
-    - configuration
+    - environment
     - bash
     - bash-aliases
 
@@ -85,7 +125,7 @@
     mode="0644"
   when: server_bash_history
   tags:
-    - configuration
+    - environment
     - bash
     - bash-history
 
@@ -97,6 +137,10 @@
   when: firewall_included
   register: firewalld
   ignore_errors: true
+  tags:
+    - environment
+    - bash
+    - bash-history
 
 - name: Reload Firewalling Since Firewalld Wiped Rules
   command: /bin/true
@@ -104,8 +148,17 @@
   when:
     - firewall_included
     - firewalld.changed
+  tags:
+    - network
+    - security
+    - firewall
 
 - name: Update Base System
   command: /bin/true
   notify: server update
   when: server_update
+  tags:
+    - environment
+    - security
+    - updates
+    - yum-updates

--- a/tasks/sysctl.yml
+++ b/tasks/sysctl.yml
@@ -1,0 +1,39 @@
+- name: Set Base Sysctl
+  sysctl:
+    name="{{ item.key }}"
+    value="{{ item.value }}"
+    state="present"
+    sysctl_set="yes"
+    ignoreerrors="yes"
+    reload="yes"
+  with_items: "{{ server_sysctl }}"
+  tags:
+    - kernel-sysctl
+    - kernel-sysctl-base
+
+- name: Set Sysctl For 10G Networking
+  sysctl:
+    name="{{ item.key }}"
+    value="{{ item.value }}"
+    state="present"
+    sysctl_set="yes"
+    ignoreerrors="yes"
+    reload="yes"
+  with_items: "{{ server_sysctl_10g }}"
+  when: server_set_sysctl_10g
+  tags:
+    - kernel-sysctl
+    - kernel-sysctl-10g
+
+- name: Set Extra Sysctl
+  sysctl:
+    name="{{ item.key }}"
+    value="{{ item.value }}"
+    state="present"
+    sysctl_set="yes"
+    ignoreerrors="yes"
+    reload="yes"
+  with_items: "{{ server_extra_sysctl }}"
+  tags:
+    - kernel-sysctl
+    - kernel-sysctl-extra


### PR DESCRIPTION
[New] first pass at appropriate tagging for tasks to allow task-specific execution on play w/ e.g --tags='kernel-sysctl'
[Change] additional tagging inside limits.yml; ideally sysctl stuff needs to break out or go back in main.yml
[Change] moved sysctl tasks into sysctl.yml, limits.yml now for pam /related resource limits
[Change] added server_set_sysctl_base (true) and server_set_sysctl_10g (false) variables and refactored sysctl tasks accordingly
[New] added base sysctl values into server_sysctl list as follows:
net.core.netdev_max_backlog
net.ipv4.tcp_max_tw_buckets
net.ipv4.tcp_max_syn_backlog
net.ipv4.tcp_syn_retries
net.ipv4.tcp_synack_retries
net.ipv4.tcp_fin_timeout
net.netfilter.nf_conntrack_max
[New] added sysctl values to achieve line rate 10G speeds into server_sysctl_10g list as follows:
net.core.rmem_max
net.core.wmem_max
net.ipv4.tcp_rmem
net.ipv4.tcp_wmem
net.ipv4.tcp_slow_start_after_idle
net.ipv4.tcp_sack
net.ipv4.tcp_window_scaling
net.ipv4.tcp_moderate_rcvbuf