### PR TITLE
Default package additions and added skipbroken/update_cache to yum task

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,8 +11,11 @@ epel_included: true
 server_update: false
 server_selinux_enforcing: false
 server_packages:
+  - "bash-completion"
+  - "bind-utils"
   - "bridge-utils"
   - "bzip2"
+  - "deltarpm"
   - "ed"
   - "emacs-nox"
   - "git"
@@ -21,7 +24,6 @@ server_packages:
   - "iputils"
   - "jq"
   - "libselinux-python"
-  - "selinux-policy-targeted"
   - "lsof"
   - "lynx"
   - "mailx"
@@ -33,13 +35,13 @@ server_packages:
   - "python-devel"
   - "rsync"
   - "screen"
+  - "selinux-policy-targeted"
   - "strace"
   - "sudo"
   - "tcpdump"
   - "telnet"
   - "unzip"
   - "vim"
-  - "bind-utils"
 server_extra_packages: []
 server_extra_path:
 server_services_unused: []

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 
 - name: server update
-  yum: name=* update_cache=yes state=latest
+  yum: name=* update_cache=yes state=latest skip_broken=yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,8 @@
     state="present"
     disablerepo="*"
     enablerepo="epel,base,updates,nexcess,extras"
+    skip_broken: yes
+    update_cache: yes
   with_items: "{{ server_packages + server_extra_packages }}"
   tags:
     - packages

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,8 +24,8 @@
     state="present"
     disablerepo="*"
     enablerepo="epel,base,updates,nexcess,extras"
-    skip_broken: yes
-    update_cache: yes
+    skip_broken=yes
+    update_cache=yes
   with_items: "{{ server_packages + server_extra_packages }}"
   tags:
     - packages


### PR DESCRIPTION
[Change] Set the yum task to skip_broken=yes and update_cache=yes which allows for more graceful handling of package conflicts between repositories. This is a better option than simply ignoring errors I think.
[Change] Added bash-completion and deltarpm to default package list. The deltarpm package allows for much faster yum update tasks and w/ reduced bw.