### PR TITLE
include ansible version requirement in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Base Ansible role for a Nexcess "server".  This role should be common across all
 
 Lots, but just about everything is overridable.  See [defaults/main.yml](https://github.com/nexcess/ansible-role-server/blob/master/defaults/main.yml)
 
+
+## Requirements
+- Ansible-playbook 2.3 or greater.
+
 ## Dependencies
 
 - nexcess.firewall


### PR DESCRIPTION
```
$ ansible-playbook --version
ansible-playbook 2.2.1.0
  config file = ./ansible.cfg
  configured module search path = Default w/o overrides


TASK [nexcess.server : Install Extras] *****************************************
failed: [ammit-data01.us-midwest-1.nexcess.net] (item=[u'bash-completion', u'bind-utils', u'bridge-utils', u'bzip2', u'deltarpm', u'ed', u'emacs-nox', u'git', u'iptables', u'iptables-services', u'iputils', u'jq', u'libselinux-python', u'lsof', u'lynx', u'mailx', u'mlocate', u'nc', u'net-tools', u'pigz', u'policycoreutils-python', u'python-devel', u'rsync', u'screen', u'selinux-policy-targeted', u'setroubleshoot-server', u'strace', u'sudo', u'tcpdump', u'telnet', u'unzip', u'vim', u'bind-utils', u's3cmd']) => {"failed": true, "item": ["bash-completion", "bind-utils", "bridge-utils", "bzip2", "deltarpm", "ed", "emacs-nox", "git", "iptables", "iptables-services", "iputils", "jq", "libselinux-python", "lsof", "lynx", "mailx", "mlocate", "nc", "net-tools", "pigz", "policycoreutils-python", "python-devel", "rsync", "screen", "selinux-policy-targeted", "setroubleshoot-server", "strace", "sudo", "tcpdump", "telnet", "unzip", "vim", "bind-utils", "s3cmd"], "msg": "unsupported parameter for module: skip_broken"}
```

Failing on: [tasks/main.yml#L27]( https://github.com/nexcess/ansible-role-server/blob/ec825497ce378e5b1ead359ca0bba968f563ce06/tasks/main.yml#L27)

After updating ansible, no errors.
```
$ ansible-playbook --version
ansible-playbook 2.3.1.0
  config file = ./ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.10 (default, Jul 30 2016, 19:40:32) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```