### PR TITLE
Overriding EPEL To Combat Issues

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,6 +49,7 @@ server_extra_packages: []
 server_extra_path:
 server_services_unused: []
 server_adjust_limits: true
+server_override_epel: true
 server_pam:
   nofile:
     soft: 999999

--- a/tasks/epel-override.yml
+++ b/tasks/epel-override.yml
@@ -12,5 +12,5 @@
     path="{{ epel_repofile_path }}"
     section="epel"
     option="baseurl"
-    value="https://imirror.us-midwest-1.nexcess.net/epel/$releasever/$basearch/"
+    value="https://imirror.{{ nex_zone }}.nexcess.net/epel/$releasever/$basearch/"
     backup=false

--- a/tasks/epel-override.yml
+++ b/tasks/epel-override.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Remove Mirrorlist for EPEL to Perfer Nexcess
+  ini_file:
+    path="{{ epel_repofile_path }}"
+    section="epel"
+    option="mirrorlist"
+    state="absent"
+
+- name: Add in the Nexcess BaseURL
+  ini_file:
+    path="{{ epel_repofile_path }}"
+    section="epel"
+    option="baseurl"
+    value="https://imirror.us-midwest-1.nexcess.net/epel/$releasever/$basearch/"
+    backup=false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,7 @@
 ---
 
+- include: epel-override.yml
+
 - name: Set the Hostname
   hostname:
     name="{{ inventory_hostname }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 
 - include: epel-override.yml
+  when: server_override_epel
 
 - name: Set the Hostname
   hostname:


### PR DESCRIPTION
```fatal: [varnish-47066.us-midwest-1]: FAILED! => {"changed": false, "failed": true, "msg": "Failure talking to yum: failure: repodata/repomd.xml from epel: [Errno 256] No more mirrors to try.\nhttps://mirror.us-midwest-1.nexcess.net/epel/7/x86_64/repodata/repomd.xml: [Errno -1] repomd.xml does not match metalink for epel\nhttp://mirror.sfo12.us.leaseweb.net/epel/7/x86_64/repodata/repomd.xml: [Errno -1] repomd.xml does not match metalink for epel\nhttp://mirrors.syringanetworks.net/fedora-epel/7/x86_64/repodata/repomd.xml: [Errno -1] repomd.xml does not match metalink for epel\nhttp://fedora-epel.mirror.lstn.net/7/x86_64/repodata/repomd.xml: 