### PR TITLE
split out hosts.yml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ backnet_host: "{{ inventory_hostname }}-int"
 kernelcare_included: false
 epel_included: true
 remi_included: true
+hosts_file_included: true
 
 # Server Defaults
 server_update: true

--- a/tasks/hosts.yml
+++ b/tasks/hosts.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Setup /etc/hosts
+  template:
+    src="etc/hosts.j2"
+    dest="/etc/hosts"
+    owner="root"
+    group="root"
+    mode="0644"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,7 +61,7 @@
     - security
     - selinux
     - selinux-enforcing
-  
+
 - name: 'Ensure mount point options'
   lineinfile:
     path: /etc/fstab
@@ -131,13 +131,7 @@
     - kernel
     - kernel-udev
 
-- name: Setup /etc/hosts
-  template:
-    src="etc/hosts.j2"
-    dest="/etc/hosts"
-    owner="root"
-    group="root"
-    mode="0644"
+- include: hosts.yml
   tags:
     - environment
     - hosts

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -132,6 +132,7 @@
     - kernel-udev
 
 - include: hosts.yml
+  when: hosts_file_included
   tags:
     - environment
     - hosts


### PR DESCRIPTION
This is needed for an add-worker playbook I'm building for NocWorx. It does not have any affect on existing playbooks that use it, but will allow you to specifically target this task if needed.

```
include_role:
  name: nexcess.server
  tasks_from: hosts.yml
```