### PR TITLE
don't disable all on pkg installs

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,6 @@
   yum:
     name="{{ item }}"
     state="present"
-    disablerepo="*"
     enablerepo="epel,remi,base,updates,extras"
     skip_broken=yes
     update_cache=yes


### PR DESCRIPTION
to potentially work around issues when deploying, due to ansible not being able to see the package