### PR TITLE
NSE-7487 fix setting path

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
     dest="/etc/environment"
     state="present"
     line="PATH={{ server_extra_path + ":" }}/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin"
-  when: server_extra_path != ''
+  when: server_extra_path is defined and server_extra_path|length > 0
   tags:
     - environment
     - paths


### PR DESCRIPTION
should fix:
```
TASK [nexcess.server : Set the Global PATH] ************************************
[0;31mfatal: [cloudhost-2704569.us-midwest-1.nxcli.net]: FAILED! => {"msg": "Unexpected templating type error occurred on (PATH={{ server_extra_path + \":\" }}/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin): unsupported operand type(s) for +: 'NoneType' and 'str'"}[0m
```