### PR TITLE
We need to clear yum cache

### DIFF
--- a/tasks/epel-override.yml
+++ b/tasks/epel-override.yml
@@ -25,3 +25,6 @@
     section="epel"
     option="baseurl"
     value="https://{{ server_epel_mirror }}/epel/$releasever/$basearch/"
+
+- name: Clearing yum cache after switching BaseURL
+  command: /usr/bin/yum clean expire-cache


### PR DESCRIPTION
Clearing yum cache prevents build failures when the metadata for upstream EPEL does not match our own